### PR TITLE
Fix a compatibility issue with Guzzle

### DIFF
--- a/lib/FH/PostcodeAPIClient/FHPostcodeAPIClient.php
+++ b/lib/FH/PostcodeAPIClient/FHPostcodeAPIClient.php
@@ -43,9 +43,9 @@ class FHPostcodeAPIClient extends Client
     /**
      * {@inheritdoc}
      */
-    public function createRequest($method = RequestInterface::GET, $uri = null, $headers = null, $body = null)
+    public function createRequest($method = RequestInterface::GET, $uri = null, $headers = null, $body = null, array $options = array())
     {
-        $request = parent::createRequest($method, $uri, $headers, $body);
+        $request = parent::createRequest($method, $uri, $headers, $body, $options);
         $request->addHeader('Api-Key', $this->getConfig('api_key'));
 
         return $request;


### PR DESCRIPTION
Declaration of FH\PostcodeAPIClient\FHPostcodeAPIClient::createRequest() must be compatible with Guzzle\Http\ClientInterface::createRequest($method = 'GET', $uri = NULL, $headers = NULL, $body = NULL, array $options = Array)
