### PR TITLE
Removed json_decode flag JSON_BIGINT_AS_STRING

### DIFF
--- a/lib/FH/PostcodeAPI/Client.php
+++ b/lib/FH/PostcodeAPI/Client.php
@@ -104,7 +104,7 @@ class Client
      */
     private function parseResponse(ResponseInterface $response)
     {
-        $out = json_decode((string) $response->getBody(), false, 512, JSON_BIGINT_AS_STRING);
+        $out = json_decode((string) $response->getBody(), false, 512);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new CouldNotParseResponseException('Could not parse resonse', $response);

--- a/lib/FH/PostcodeAPI/Client.php
+++ b/lib/FH/PostcodeAPI/Client.php
@@ -104,7 +104,7 @@ class Client
      */
     private function parseResponse(ResponseInterface $response)
     {
-        $out = json_decode((string) $response->getBody(), false, 512);
+        $out = json_decode((string) $response->getBody());
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new CouldNotParseResponseException('Could not parse resonse', $response);


### PR DESCRIPTION
As big ints are provided as strings by the fh postcode API, it is not required.