### PR TITLE
Fixed typo in 'getAddress' endpoint method (breaks api)

### DIFF
--- a/lib/FH/PostcodeAPI/Client.php
+++ b/lib/FH/PostcodeAPI/Client.php
@@ -71,7 +71,7 @@ class Client
      *
      * @return \StdClass
      */
-    public function getAddresss($id)
+    public function getAddress($id)
     {
         return $this->get("/v2/addresses/{$id}");
     }

--- a/tests/FH/PostcodeAPI/ClientTest.php
+++ b/tests/FH/PostcodeAPI/ClientTest.php
@@ -96,7 +96,7 @@ final class ClientTest extends \PHPUnit_Framework_TestCase
             $this->loadMockResponse('successful_detail_freshheads')
         );
 
-        $address = $client->getAddresss(self::FRESHHEADS_ADDRESS_ID);
+        $address = $client->getAddress(self::FRESHHEADS_ADDRESS_ID);
 
         $this->applyAddressFieldAreSetAndOfTheCorrectTypeAssertions($address);
 


### PR DESCRIPTION
https://github.com/freshheads/FHPostcodeAPIClient/pull/7 but with unit test fix.