### PR TITLE
Update readme: remove mention of API version 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ FHPostcodeAPIClient
 [![Build Status](https://travis-ci.org/freshheads/FHPostcodeAPIClient.png?branch=master)](https://travis-ci.org/freshheads/FHPostcodeAPIClient)
 
 FHPostcodeAPIClient is a PHP client library for the PostcodeAPI.nu web service. This library is developed 
-by [Freshheads](http://www.freshheads.com) and will be maintained in sync with the web service itself.
+by [Freshheads](https://www.freshheads.com) and will be maintained in sync with the web service itself.
 
 **Links:**
 
-* [More information](http://www.postcodeapi.nu)
-* [API documentation](http://www.postcodeapi.nu/docs)
+* [More information](https://www.postcodeapi.nu)
+* [API documentation](https://swaggerhub.com/api/apiwise/postcode-api)
 
 Requirements
 ------------
@@ -20,7 +20,7 @@ version is used instead of the new Guzzle 6, as Guzzle 6 requires the php versio
 Installation
 ------------
 
-FHPostcodeAPIClient can easily be installed using [Composer](http://getcomposer.org/):
+FHPostcodeAPIClient can easily be installed using [Composer](https://getcomposer.org/):
 
 ```bash
 composer require freshheads/postcode-api-client
@@ -42,16 +42,6 @@ $client = new \FH\PostcodeAPI\Client(new \GuzzleHttp\Client(), $apiKey);
 // call endpoints
 $response = $client->getAddresses('5041EB', 21);
 $response = $client->getAddress('0855200000061001');
-```
-
-Postcodeapi.nu Version 1
-------------------------
-
-Version 1 of PostcodeAPI will be available until 29-02-2016. You can still connect to this API via version 1.x of this client library.
-Version 1.x can be installed via composer:
-
-```bash
-composer require freshheads/postcode-api-client:^1.0
 ```
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/freshheads/fhpostcodeapiclient/trend.png)](https://bitdeli.com/free "Bitdeli Badge")


### PR DESCRIPTION
API v1 is no longer available, so remove that from the readme
Update the PostcodeAPI.nu docs location (old one is broken)
Update some links which redirect to https