### PR TITLE
Migrate to Guzzle 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: php
 
 php:
-    - 5.4
     - 5.5
     - 5.6
     - 7.0
+    - 7.1
 
 before_script:
-    - composer install --dev
+    - composer install
 
-script: phpunit --coverage-text
+script:
+    - composer test
 
 notifications:
     email: "travis-ci@freshheads.com"

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ by [Freshheads](https://www.freshheads.com) and will be maintained in sync with 
 Requirements
 ------------
 
-FHPostcodeAPIClient works with PHP 5.4.0 or up. This library is dependent on the awesome [Guzzle](http://guzzlephp.org/) HTTP client library. Guzzle 5 
-version is used instead of the new Guzzle 6, as Guzzle 6 requires the php version to be higher than 5.5.0.
+FHPostcodeAPIClient works with PHP 5.5 or up. This library is dependent on the awesome [Guzzle](http://guzzlephp.org/) HTTP client library.
 
 Installation
 ------------

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,11 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "^5.3"
+        "php": ">=5.5",
+        "guzzlehttp/guzzle": "^6.2"
+    },
+    "require-dev": {
+        "phpunit/phpunit": ">=4.8"
     },
     "autoload": {
         "psr-0": { "FH\\PostcodeAPI": "lib/" }
@@ -26,5 +29,8 @@
         "branch-alias": {
             "dev-master": "2.0.x-dev"
         }
+    },
+    "scripts": {
+        "test": "./vendor/phpunit/phpunit/phpunit --coverage-text"
     }
 }


### PR DESCRIPTION
Use Guzzle version 6 instead of 5.

Also streamline the testing experience by adding `require-dev` and a test script to the composer file.

Fixes #13 